### PR TITLE
Make `SnowflakeClient` thread-safe

### DIFF
--- a/Snowflake.Client/Model/SnowflakeSession.cs
+++ b/Snowflake.Client/Model/SnowflakeSession.cs
@@ -27,6 +27,10 @@ namespace Snowflake.Client
         public string WarehouseName { get; private set; }
         public string RoleName { get; private set; }
 
+        /// <summary>
+        /// Construct a <see cref="SnowflakeSession"/> after a successful login request.
+        /// </summary>
+        /// <param name="loginResponseData">Data from login response.</param>
         public SnowflakeSession(LoginResponseData loginResponseData)
         {
             this.SessionToken = loginResponseData.Token;
@@ -50,7 +54,12 @@ namespace Snowflake.Client
             this.RoleName = loginResponseData.SessionInfo.RoleName;
         }
 
-        internal void Renew(RenewSessionResponseData renewSessionResponseData)
+        /// <summary>
+        /// Construct a <see cref="SnowflakeSession"/> after a successful renew session request.
+        /// </summary>
+        /// <param name="session">The old session.</param>
+        /// <param name="renewSessionResponseData">Data from renew session response.</param>
+        public SnowflakeSession(SnowflakeSession session, RenewSessionResponseData renewSessionResponseData)
         {
             this.SessionToken = renewSessionResponseData.SessionToken;
 
@@ -58,6 +67,20 @@ namespace Snowflake.Client
             this.SessionId = renewSessionResponseData.SessionId;
             this.ValidityInSeconds = renewSessionResponseData.ValidityInSecondsST;
             this.MasterValidityInSeconds = renewSessionResponseData.ValidityInSecondsMT;
+
+            this.DisplayUserName = session.DisplayUserName;
+            this.ServerVersion = session.ServerVersion;
+            this.FirstLogin = session.FirstLogin;
+            this.RemMeToken = session.RemMeToken;
+            this.RemMeValidityInSeconds = session.RemMeValidityInSeconds;
+            this.HealthCheckInterval = session.HealthCheckInterval;
+            this.NewClientForUpgrade = session.NewClientForUpgrade;
+            this.IdToken = session.IdToken;
+            this.IdTokenValidityInSeconds = session.IdTokenValidityInSeconds;
+            this.DatabaseName = session.DatabaseName;
+            this.SchemaName = session.SchemaName;
+            this.WarehouseName = session.WarehouseName;
+            this.RoleName = session.RoleName;
         }
 
         public override string ToString()

--- a/Snowflake.Client/SnowflakeClient.cs
+++ b/Snowflake.Client/SnowflakeClient.cs
@@ -23,7 +23,7 @@ namespace Snowflake.Client
         private readonly SnowflakeClientSettings _clientSettings;
 
         /// <summary>
-        /// Creates new Snowflake client. 
+        /// Creates new Snowflake client.
         /// </summary>
         /// <param name="user">Username</param>
         /// <param name="password">Password</param>
@@ -34,8 +34,8 @@ namespace Snowflake.Client
         {
         }
 
-        /// <summary> 
-        /// Creates new Snowflake client. 
+        /// <summary>
+        /// Creates new Snowflake client.
         /// </summary>
         /// <param name="authInfo">Auth information: user, password, account, region</param>
         /// <param name="sessionInfo">Session information: role, schema, database, warehouse</param>
@@ -47,7 +47,7 @@ namespace Snowflake.Client
         }
 
         /// <summary>
-        /// Creates new Snowflake client. 
+        /// Creates new Snowflake client.
         /// </summary>
         /// <param name="settings">Client settings to initialize new session.</param>
         public SnowflakeClient(SnowflakeClientSettings settings)
@@ -91,7 +91,6 @@ namespace Snowflake.Client
         public async Task<bool> InitNewSessionAsync()
         {
             _session = await AuthenticateAsync(_clientSettings.AuthInfo, _clientSettings.SessionInfo).ConfigureAwait(false);
-            _requestBuilder.SetSessionTokens(_session.SessionToken, _session.MasterToken);
 
             return true;
         }
@@ -117,14 +116,13 @@ namespace Snowflake.Client
             if (_session == null)
                 throw new SnowflakeException("Session is not itialized yet.");
 
-            var renewSessionRequest = _requestBuilder.BuildRenewSessionRequest();
+            var renewSessionRequest = _requestBuilder.BuildRenewSessionRequest(_session);
             var response = await _restClient.SendAsync<RenewSessionResponse>(renewSessionRequest).ConfigureAwait(false);
 
             if (!response.Success)
                 throw new SnowflakeException($"Renew session failed. Message: {response.Message}", response.Code);
 
-            _session.Renew(response.Data);
-            _requestBuilder.SetSessionTokens(_session.SessionToken, _session.MasterToken);
+            _session = new SnowflakeSession(_session, response.Data);
 
             return true;
         }
@@ -195,7 +193,7 @@ namespace Snowflake.Client
         /// <param name="requestId">Request ID to cancel.</param>
         public async Task<bool> CancelQueryAsync(string requestId)
         {
-            var cancelQueryRequest = _requestBuilder.BuildCancelQueryRequest(requestId);
+            var cancelQueryRequest = _requestBuilder.BuildCancelQueryRequest(_session, requestId);
 
             var response = await _restClient.SendAsync<NullDataResponse>(cancelQueryRequest).ConfigureAwait(false);
 
@@ -212,7 +210,7 @@ namespace Snowflake.Client
                 await InitNewSessionAsync().ConfigureAwait(false);
             }
 
-            var queryRequest = _requestBuilder.BuildQueryRequest(sql, sqlParams, describeOnly);
+            var queryRequest = _requestBuilder.BuildQueryRequest(_session, sql, sqlParams, describeOnly);
             var response = await _restClient.SendAsync<QueryExecResponse>(queryRequest).ConfigureAwait(false);
 
             // Auto renew session, if it's expired
@@ -229,16 +227,15 @@ namespace Snowflake.Client
         }
 
         /// <summary>
-        /// Closes current Snowflake session. 
+        /// Closes current Snowflake session.
         /// </summary>
         /// <returns>True if session was successfully closed.</returns>
         public async Task<bool> CloseSessionAsync()
         {
-            var closeSessionRequest = _requestBuilder.BuildCloseSessionRequest();
+            var closeSessionRequest = _requestBuilder.BuildCloseSessionRequest(_session);
             var response = await _restClient.SendAsync<CloseResponse>(closeSessionRequest).ConfigureAwait(false);
 
             _session = null;
-            _requestBuilder.ClearSessionTokens();
 
             if (!response.Success)
                 throw new SnowflakeException($"Closing session failed. Message: {response.Message}", response.Code);


### PR DESCRIPTION
Change `SnowflakeSession` to be immutable; when session is renewed copy
properties from the old session into a new one.

Don't push tokens into `RequestBuilder`; instead pass the `SnowflakeSession`
to each of its methods.